### PR TITLE
fixed port gpio selection in pinMode

### DIFF
--- a/cores/arduino/wiring_digital.cpp
+++ b/cores/arduino/wiring_digital.cpp
@@ -41,9 +41,13 @@ void pinMode(pin_size_t pin, PinMode mode)
       pinConfig=GPIO_ModeIN_PD;
       break;
   }
-  GPIOA_ModeCfg(1 << (pin),pinConfig);
-  GPIOB_ModeCfg(1 << (pin - 16),pinConfig);
 
+  if (pin <16){
+  GPIOA_ModeCfg(1 << (pin),pinConfig);
+  }
+  else{
+  GPIOB_ModeCfg(1 << (pin - 16),pinConfig);
+  }
 }
 
 


### PR DESCRIPTION
This update is a small fix for potentially undefined behavior as both GPIOA_ModeCfg and GPIOB_ModeCfg were called in sequence instead of alternatively based on the pin value. 
More info:
The 1<<(pin-16) expression is undefined for pin values less than 16.
Some implementations might return 0, some others might consider other options.
In particular for the following sequence (that shows the effect of 1<<i and 1<<(i-16)):
 for (i=0;i<40;i++)
  {
    pin_size_t p = i;
    sprintf(buff,"Pin %d, px:%X px16:%X\r\n",i, 1<<p, 1<<(p-16));
    UART1_SendString((uint8_t *)buff, strlen(buff));
  }
we have the following output on ch582:
Pin 0, px:1 px16:10000
Pin 1, px:2 px16:20000
Pin 2, px:4 px16:40000
Pin 3, px:8 px16:80000
Pin 4, px:10 px16:100000
Pin 5, px:20 px16:200000
Pin 6, px:40 px16:400000
Pin 7, px:80 px16:800000
Pin 8, px:100 px16:1000000
Pin 9, px:200 px16:2000000
Pin 10, px:400 px16:4000000
Pin 11, px:800 px16:8000000
Pin 12, px:1000 px16:10000000
Pin 13, px:2000 px16:20000000
Pin 14, px:4000 px16:40000000
Pin 15, px:8000 px16:80000000
Pin 16, px:10000 px16:1
Pin 17, px:20000 px16:2
Pin 18, px:40000 px16:4
Pin 19, px:80000 px16:8
Pin 20, px:100000 px16:10
Pin 21, px:200000 px16:20
Pin 22, px:400000 px16:40
Pin 23, px:800000 px16:80
Pin 24, px:1000000 px16:100
Pin 25, px:2000000 px16:200
Pin 26, px:4000000 px16:400
Pin 27, px:8000000 px16:800
Pin 28, px:10000000 px16:1000
Pin 29, px:20000000 px16:2000
Pin 30, px:40000000 px16:4000
Pin 31, px:80000000 px16:8000
Pin 32, px:1 px16:10000
Pin 33, px:2 px16:20000
Pin 34, px:4 px16:40000
Pin 35, px:8 px16:80000
Pin 36, px:10 px16:100000
Pin 37, px:20 px16:200000
Pin 38, px:40 px16:400000
Pin 39, px:80 px16:800000

Given the above, it is clear that calling both functions in sequence can lead to unwanted register writes that could either change unwanted pins state or write to reserved bits.
